### PR TITLE
[Xenial] Add some more to ros-industrial/industrial_ci/pull/52

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,12 @@ env:
     - ROS_DISTRO=indigo APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=jade   APTKEY_STORE_SKS=hkp://ha.pool.sks-keyservers.vet  # Passing wrong SKS URL as a break test. Should still pass.
     - ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1
+    - ROS_DISTRO=kinetic
 matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo PRERELEASE=true PRERELEASE_REPONAME=industrial_core PRERELEASE_DOWNSTREAM_DEPTH=0
     - env: ROS_DISTRO=jade   PRERELEASE=true PRERELEASE_REPONAME=warehouse_ros PRERELEASE_DOWNSTREAM_DEPTH=1  # Intended to fail (as of Apr 2016), to test the capability of capturing Prerelease Test failure.
+    - env: ROS_DISTRO=kinetic
 before_script:
   - CI_DIR=.ci_config
   - mkdir $CI_DIR; cp * $CI_DIR  # Need to copy, since directory starting from dot is ignoreed by catkin build. Also this folder name is used for testing both this repo itself and the "client" repositories

--- a/travis.sh
+++ b/travis.sh
@@ -51,6 +51,8 @@ if [[ "$ROS_DISTRO" == "kinetic" ]] && ! [ "$IN_DOCKER" ]; then
   travis_time_start build_docker_image
   docker build -t industrial-ci/xenial .ci_config
   travis_time_end  # build_docker_image
+
+  travis_time_start run_travissh_docker
   docker run \
       -e ROS_REPOSITORY_PATH \
       -e ROS_DISTRO \
@@ -75,6 +77,7 @@ if [[ "$ROS_DISTRO" == "kinetic" ]] && ! [ "$IN_DOCKER" ]; then
       -e USE_DEBROS_DISTRO \
       -v $(pwd):/root/ci_src industrial-ci/xenial \
       /bin/bash -c "cd /root/ci_src; source .ci_config/travis.sh;"
+  travis_time_end  # run_travissh_docker
   exit 0
 fi
 


### PR DESCRIPTION
Some addition to your https://github.com/ros-industrial/industrial_ci/pull/52
- https://github.com/evenator/industrial_ci/commit/27159ad7dd31338e454f7d2b0584c41013bee883 adds a Travis job for Kinetic.
- https://github.com/evenator/industrial_ci/commit/71b80f71cd07fdaa900daa30a6f331f03a7d6d62 folds the docker run section.

As you know once you merge this into your branch, https://github.com/ros-industrial/industrial_ci/pull/52 will get updated.
